### PR TITLE
Updated CardDealer interface, testing pay method from dealer

### DIFF
--- a/src/main/java/io/zipcoder/zealotscasino/CardDealer.java
+++ b/src/main/java/io/zipcoder/zealotscasino/CardDealer.java
@@ -11,5 +11,5 @@ public interface CardDealer
 
     void takeTurn();
 
-    double pay(Player player, double payOut);
+    void pay(Player player, double payOut);
 }


### PR DESCRIPTION
Changed pay to return void instead of double in CardDealer interface. Made test for pay and failed. Now to pass.