### PR TITLE
fixed error in BigSixDealer;&added tests to TestBigSixDealer

### DIFF
--- a/src/main/java/io/zipcoder/zealotscasino/BigSixDealer.java
+++ b/src/main/java/io/zipcoder/zealotscasino/BigSixDealer.java
@@ -24,7 +24,6 @@ public class BigSixDealer implements Dealer {
         playRound(player);
         UserInput.display(player.printWallet());
         askPlayAgain(player);
-        bet = new Bet();
     }
 
     @Override
@@ -51,18 +50,22 @@ public class BigSixDealer implements Dealer {
 
     public void takeBetsAndDenominations(Player player) {
         boolean quit = false;
+        double amount = 0;
 
         while (!quit){
             UserInput.display("Enter a denomination on the wheel to determine your pay out ratio\n1 : You win your bet * 1\n2 : You win your bet * 2\n5: You win your bet * 5\n10 : You win your bet * 10\n20 : You win your bet * 20\nJOKER : You win your bet * 40\nCASINO : You win your bet * 40\n");
             String denominationChoice = UserInput.getStringInput("Which denomination would you like to place a bet on? (or n if done placing bets)");
-
             if (denominationChoice.equalsIgnoreCase("n")) {quit = true;}
             else if (denominationChoice.equals("1") || denominationChoice.equals("2") || denominationChoice.equals("5") || denominationChoice.equals("10") || denominationChoice.equals("20") || denominationChoice.equalsIgnoreCase("JOKER") || denominationChoice.equalsIgnoreCase("CASINO"))
             {
-                if(bet.makeBet(UserInput.getIntInput("How much would you like to bet?"), player)){
-                    wheelBets.add(new WheelBet(player, bet.getBetValue(), denominationChoice));
+                bet = new Bet();
+//                if(bet.makeBet(UserInput.getDoubleInput("How much would you like to bet?"), player)){
+//                    player.setWallet(player.getWallet() + bet.getBetValue());
+                    amount = UserInput.getDoubleInput("How much would you like to bet?");
+                    wheelBets.add(new WheelBet(player, amount, denominationChoice));
+                    //wheelBets.add(new WheelBet(player, bet.getBetValue(), denominationChoice));
                     UserInput.display("\n" + player.printWallet() + "\n");
-                }
+                //}
             }
             else {UserInput.display("You must enter a valid denomination.");}
         }
@@ -109,7 +112,7 @@ public class BigSixDealer implements Dealer {
         int payOutRatio = checkIfWon(winningDenomination);
         for (WheelBet wheelBet : wheelBets) {
             if (wheelBet.getLocationOnWheel().equalsIgnoreCase(winningDenomination)) {
-                pay(player, payOutRatio * wheelBet.getBetValue());
+                pay(player, wheelBet.getBetValue()+ payOutRatio * wheelBet.getBetValue());
                 UserInput.display("Your bet of $" + wheelBet.getBetValue() + " on denomination " + wheelBet.getLocationOnWheel() + " netted " + (wheelBet.getBetValue() * payOutRatio) + "!!");
             } else {
                 UserInput.display("Your bet of $" + wheelBet.getBetValue() + " on denomination " + wheelBet.getLocationOnWheel() + " did not hit...");
@@ -119,12 +122,12 @@ public class BigSixDealer implements Dealer {
 
 
     public void askPlayAgain(Player player) {
-        if (player.getWallet() > Bet.MINIMUM_BET) {
+        if (player.getWallet() >= Bet.MINIMUM_BET) {
             String choice = UserInput.getStringInput("Would you like to play again? (Push 'Y' to play again, 'Any other key' to quit big six)");
             if (choice.equalsIgnoreCase("Y")) {
                 wheelBets.clear();
                 play(player);
             } else UserInput.display("Thanks for playing!\n\n");
-        } else {UserInput.display("You can do a lot with $" + player.getWallet() + ". Just not in here.\n");}
+        } else {UserInput.display("Maybe you can do a lot with $" + player.getWallet() + "...outside this casino.\n");}
     }
 }

--- a/src/test/java/io/zipcoder/zealotscasino/TestBigSixDealer.java
+++ b/src/test/java/io/zipcoder/zealotscasino/TestBigSixDealer.java
@@ -1,6 +1,7 @@
 package io.zipcoder.zealotscasino;
 
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -10,16 +11,75 @@ import static org.junit.Assert.assertEquals;
  * Created by stephenpegram on 5/11/17.
  */
 public class TestBigSixDealer {
+    BigSixDealer dealer;
+    Player player;
+
+    @Before
+    public void setUp() {
+        player = new Player();
+        dealer = new BigSixDealer();
+    }
 
     @Test
     public void initializeWheelDenominations_NumberOfDenominations_Returns54() {
         //Given
-        BigSixDealer wheelDealer = new BigSixDealer();
         int expected = 54;
 
         //When
-        wheelDealer.initializeWheelDenominations();
-        int actual = wheelDealer.getWheelDenominations().size();
+        dealer.initializeWheelDenominations();
+        int actual = dealer.getWheelDenominations().size();
+
+        //Then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void checkIfWon_WinningDenominationIs1_ReturnsPayOutOf1() {
+        //Given
+        String winningDenomination = "1";
+        int expected = 1;
+
+        //When
+        int actual = dealer.checkIfWon(winningDenomination);
+
+        //Then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void checkIfWon_WinningDenominationIs2_ReturnsPayOutOf2() {
+        //Given
+        String winningDenomination = "2";
+        int expected = 2;
+
+        //When
+        int actual = dealer.checkIfWon(winningDenomination);
+
+        //Then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void checkIfWon_WinningDenominationIs5_ReturnsPayOutOf5() {
+        //Given
+        String winningDenomination = "5";
+        int expected = 5;
+
+        //When
+        int actual = dealer.checkIfWon(winningDenomination);
+
+        //Then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void checkIfWon_WinningDenominationIs10_ReturnsPayOutOf10() {
+        //Given
+        String winningDenomination = "10";
+        int expected = 10;
+
+        //When
+        int actual = dealer.checkIfWon(winningDenomination);
 
         //Then
         assertEquals(expected, actual);
@@ -28,12 +88,11 @@ public class TestBigSixDealer {
     @Test
     public void checkIfWon_WinningDenominationIs20_ReturnsPayOutOf20() {
         //Given
-        BigSixDealer wheelDealer = new BigSixDealer();
         String winningDenomination = "20";
         int expected = 20;
 
         //When
-        int actual = wheelDealer.checkIfWon(winningDenomination);
+        int actual = dealer.checkIfWon(winningDenomination);
 
         //Then
         assertEquals(expected, actual);
@@ -42,50 +101,58 @@ public class TestBigSixDealer {
     @Test
     public void checkIfWon_WinningDenominationIsJOKER_ReturnsPayOutOf40() {
         //Given
-        BigSixDealer wheelDealer = new BigSixDealer();
         String winningDenomination = "JOKER";
         int expected = 40;
 
         //When
-        int actual = wheelDealer.checkIfWon(winningDenomination);
+        int actual = dealer.checkIfWon(winningDenomination);
 
         //Then
         assertEquals(expected, actual);
     }
 
-    /*@Test
+    @Test
+    public void checkIfWon_WinningDenominationIsCASINO_ReturnsPayOutOf40() {
+        //Given
+        String winningDenomination = "CASINO";
+        int expected = 40;
+
+        //When
+        int actual = dealer.checkIfWon(winningDenomination);
+
+        //Then
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void payOut_PlayerWinsOn20Denomination_PlayersWalletIncreasesBy20() {
         //Given
-        BigSixDealer wheelDealer = new BigSixDealer();
-        Player player = new Player();
         Bet bet = new Bet();
         player.setWallet(100);
         bet.makeBet(20, player);
         int payOutRatio = 20;
         double expected = 500;
         //When
-        wheelDealer.pay(player, payOutRatio * bet.getBetValue());
+        dealer.pay(player, bet.getBetValue() + payOutRatio * bet.getBetValue());
         double actual = player.getWallet();
         //Then
-        assertEquals(expected, actual,0);
-    } */
+        assertEquals(expected, actual, 0);
+    }
 
-    /* @Test
-    public void payOut_PlayerDoesNotWinOnAnyDenomination_PlayersWalletDoesNotIncrease(){
-    //Given
-        BigSixDealer wheelDealer = new BigSixDealer();
+    @Test
+    public void payOut_PlayerDoesNotWinOnAnyDenomination_PlayersWalletDoesNotIncrease() {
+        //Given
         Bet bet = new Bet();
-        Player player = new Player();
         player.setWallet(100);
         bet.makeBet(20, player);
         int payOutRatio = -1;
         double expected = 80;
-    //When
-        wheelDealer.pay(player, payOutRatio * bet.getBetValue());
+        //When
+        dealer.pay(player, bet.getBetValue() + payOutRatio * bet.getBetValue());
         double actual = player.getWallet();
-    //Then
-        assertEquals(expected, actual,0);
-    } */
+        //Then
+        assertEquals(expected, actual, 0);
+    }
 
 
 }


### PR DESCRIPTION
-fixed error in  'takeBetsAndDenominations()' that gave a NullPointerException due to a new bet object being instantiated at the end of the 'playround()' (after makeBet() is called instead of before makeBet() is called).

-created a double variable 'amount' that store's the user's bet and uses that as an argument to the constructor for WheelBet, rather than bet.getBetValue 
(A bet has to be made to initialize getBetValue, and since the WheelBet constructor was edited to call makeBet() from the Bet class, using makeBet() to set the bet amount in order to call the WheelBet constructor with  bet.getBetValue() as an argument will cause the bet to be made twice)

-fixed infinite loops in 
`payOut_PlayerDoesNotWinOnAnyDenomination_PlayersWalletDoesNotIncrease()` and `payOut_PlayerWinsOn20Denomination_PlayersWalletIncreasesBy20()`
located in the TestBigSixDealer class (Game class and BigSixDealer classes were edited to allow a new BigSixDealer object to refer to the Dealer interface, but the test methods was still instantiating a new BigSixDealer object based on the old, deleted instantiation of BigSixDealer object that referred to type BigSixDealer).

-added tests for all other cases in checkIfWon() switch block
'checkIfWon_WinningDenominationIs1_ReturnsPayOutOf1()'
'checkIfWon_WinningDenominationIs2_ReturnsPayOutOf2()'
'checkIfWon_WinningDenominationIs5_ReturnsPayOutOf5()'
'checkIfWon_WinningDenominationIs10_ReturnsPayOutOf10()'
'checkIfWon_WinningDenominationIsCASINO_ReturnsPayOutOfCASINO()'